### PR TITLE
Add morphing logic to move into toothed-backbone formation

### DIFF
--- a/players/g2_player.py
+++ b/players/g2_player.py
@@ -29,15 +29,13 @@ def show_amoeba_map(amoeba_map: npt.NDArray, retracts=[], extends=[]) -> None:
     map = np.zeros((constants.map_dim, constants.map_dim), dtype=np.int8)
     for x in range(constants.map_dim):
         for y in range(constants.map_dim):
+            # transpose map for visualization as we add cells
             if retracts_map[x, y] == 1:
-                map[x, y] = -1
+                map[y, x] = -1
             elif extends_map[x, y] == 1:
-                map[x, y] = 2
+                map[y, x] = 2
             elif amoeba_map[x, y] == 1:
-                map[x, y] = 1
-                
-            # Transpose map for visualization
-            map[y, x] = map[x, y]
+                map[y, x] = 1
     
     plt.rcParams["figure.figsize"] = (10, 10)
     plt.pcolormesh(map, edgecolors='k', linewidth=1)
@@ -97,13 +95,20 @@ class Player:
         center_x = constants.map_dim // 2
         center_y = constants.map_dim // 2
         
-        backbone_size = size // 3 * 2 + 2
-        teeth_size = size - backbone_size
+        backbone_size = ((size // 5) * 2) + 2
+        teeth_size = size - (backbone_size * 2)
+        
+        # print("size: {}, backbone_size: {}, teeth_size: {}".format(size, backbone_size, teeth_size))
         
         formation[center_x, center_y] = 1
-        for i in range(1, (backbone_size - 1) // 2 + 1):
+        formation[center_x - 1, center_y] = 1
+        for i in range(1, ((backbone_size - 1) // 2) + 1):
+            # first layer of backbone
             formation[center_x, center_y + i] = 1
             formation[center_x, center_y - i] = 1
+            # second layer of backbone
+            formation[center_x - 1, center_y + i] = 1
+            formation[center_x - 1, center_y - i] = 1
         for i in range(1, teeth_size + 1, 2):
             formation[center_x + 1, center_y + i] = 1
             formation[center_x + 1, center_y - i] = 1


### PR DESCRIPTION
## Small Improvements/Helpers Added
- Adds helper functions to go between maps and cell coord lists
- Adds helper to plot a given amoeba state, potential retracts, and potential extends 
<img width="500" alt="Screen Shot 2022-11-20 at 9 07 37 PM" src="https://user-images.githubusercontent.com/47999491/202945522-2918e5f2-f0fe-402c-8736-d143d3720f5c.png">

- Stores current move percept data as class variables for easier access
- Ports 'check move' code from simulator to check any given move's validity

## Main Functionality Added

- Adds helper to generate 'tooth formation' given a certain size amoeba 

- Adds helper to generate moves that get us from current amoeba state to a desired state (how to _morph_ into the new state)