### PR TITLE
Add translation to tooth formation

### DIFF
--- a/players/g2_player.py
+++ b/players/g2_player.py
@@ -316,8 +316,11 @@ class Player:
         
         if memory_fields[MemoryFields.Initialized]:
             curr_backbone_col = min(x for x, _ in map_to_coords(self.amoeba_map))
+            vertical_shift = curr_backbone_col % 2
             offset = (curr_backbone_col + 1) - (constants.map_dim // 2)
             next_tooth = np.roll(self.generate_tooth_formation(self.current_size), offset + 1, 0)
+            # Shift up/down by 1 every other column
+            next_tooth = np.roll(next_tooth, vertical_shift, 1)
             retracts, moves = self.get_morph_moves(next_tooth)
             print(retracts,  moves)
 


### PR DESCRIPTION
Translate the tooth formation to the right after it's built the first time. Teeth rows shift up/down by one each time we translate over by 1. Also adds memory read/write utils.

Known bug: throws when the formation reaches 100 tall.

Without alternation:
https://user-images.githubusercontent.com/3701912/202946364-7b44373a-5a42-437d-9c99-1a34b5bc6911.mp4

With alternation:

https://user-images.githubusercontent.com/3701912/202951478-e4e8aa64-f9ac-4f40-bf7d-171c7b5c2dfd.mp4





